### PR TITLE
fix: bake fitted params into DiscoveredFormula.eml_tree

### DIFF
--- a/src/symreg/constants.rs
+++ b/src/symreg/constants.rs
@@ -57,6 +57,23 @@ pub(super) fn bake_params_into_lowered(topology: &EmlTree, params: &[f64]) -> Lo
     replace_const_one(&lowered, params, &mut param_idx)
 }
 
+/// Bake learned parameters directly into an `EmlTree`, replacing each `One`/
+/// `Const` leaf (in left-to-right traversal order) with the corresponding
+/// fitted value from `params`.
+///
+/// This is the `EmlTree`-level counterpart to [`bake_params_into_lowered`]:
+/// callers that need a self-contained, directly-evaluable `EmlTree` (rather
+/// than a `LoweredOp`) for a [`crate::symreg::DiscoveredFormula`] should use
+/// this instead of returning the bare, unparameterized topology.
+pub(super) fn bake_params_into_tree(topology: &EmlTree, params: &[f64]) -> EmlTree {
+    if params.is_empty() {
+        return topology.clone();
+    }
+    let mut idx = 0usize;
+    let new_root = substitute_params(&topology.root, params, &mut idx);
+    EmlTree::from_node(new_root)
+}
+
 fn substitute_params(
     node: &crate::tree::EmlNode,
     params: &[f64],

--- a/src/symreg/discover.rs
+++ b/src/symreg/discover.rs
@@ -696,7 +696,7 @@ impl SymRegEngine {
         let (aic, bic) = compute_aic_bic(final_mse, inputs.len(), best_params.len());
 
         Some(DiscoveredFormula {
-            eml_tree: topology.clone(),
+            eml_tree: super::constants::bake_params_into_tree(topology, &best_params),
             mse: final_mse,
             complexity,
             score: final_mse + self.config.complexity_penalty * complexity as f64,

--- a/src/symreg/discover_shared.rs
+++ b/src/symreg/discover_shared.rs
@@ -6,7 +6,7 @@
 
 use crate::tree::EmlTree;
 
-use super::constants::bake_params_into_lowered;
+use super::constants::{bake_params_into_lowered, bake_params_into_tree};
 use super::topology::{dedupe_by_semantics, enumerate_topologies_gated};
 use super::{DiscoveredFormula, SharedFormula, SymRegEngine};
 
@@ -201,7 +201,7 @@ pub(super) fn shared_to_multi_result(
             let aic = n * rss_per_n.ln() + 2.0 * k;
             let bic = n * rss_per_n.ln() + k * n.max(1.0_f64).ln();
             let df = DiscoveredFormula {
-                eml_tree: sf.eml_tree.clone(),
+                eml_tree: bake_params_into_tree(&sf.eml_tree, params),
                 mse,
                 complexity,
                 score,

--- a/src/symreg/optimize_lm.rs
+++ b/src/symreg/optimize_lm.rs
@@ -331,7 +331,7 @@ pub(super) fn optimize_topology_lm(
     let (aic, bic) = compute_aic_bic(final_mse, inputs.len(), best_params.len());
 
     Some(DiscoveredFormula {
-        eml_tree: topology.clone(),
+        eml_tree: super::constants::bake_params_into_tree(topology, &best_params),
         mse: final_mse,
         complexity,
         score: final_mse + config.complexity_penalty * complexity as f64,

--- a/tests/symreg_eml_tree_consistency_test.rs
+++ b/tests/symreg_eml_tree_consistency_test.rs
@@ -1,0 +1,81 @@
+//! Regression test for `DiscoveredFormula.eml_tree` being consistent with
+//! `mse`/`pretty`/`params`: evaluating `eml_tree` directly on the training
+//! data must reproduce (approximately) the reported `mse`.
+//!
+//! Before the fix, `eml_tree` was the *unparameterized* topology (the
+//! optimizer's fitted `params` were never substituted into it), so
+//! `eml_tree.eval_batch(...)` silently returned values unrelated to the
+//! formula described by `pretty`/`mse`.
+
+use oxieml::symreg::{SymRegConfig, SymRegEngine};
+use oxieml::{EvalCtx, OptimizerKind};
+
+fn assert_eml_tree_matches_reported_mse(inputs: &[Vec<f64>], targets: &[f64], config: SymRegConfig) {
+    let engine = SymRegEngine::new(config);
+    let formulas = engine.discover(inputs, targets, 1).unwrap();
+    assert!(!formulas.is_empty());
+
+    let best = &formulas[0];
+
+    // Evaluate the returned `eml_tree` directly, the same way every README
+    // example does, and recompute MSE from scratch.
+    let mut manual_mse = 0.0;
+    let mut n = 0usize;
+    for (input, &target) in inputs.iter().zip(targets) {
+        let ctx = EvalCtx::new(input);
+        if let Ok(pred) = best.eml_tree.eval_real(&ctx) {
+            if pred.is_finite() {
+                manual_mse += (pred - target).powi(2);
+                n += 1;
+            }
+        }
+    }
+    assert!(n > 0, "eml_tree produced no finite predictions at all");
+    manual_mse /= n as f64;
+
+    assert!(
+        (manual_mse - best.mse).abs() < 1e-6 * manual_mse.max(1.0),
+        "eml_tree's own evaluation (mse={manual_mse:.6e} over {n}/{} points) \
+         does not match the formula's reported mse ({:.6e}); pretty = {}, params = {:?}",
+        inputs.len(),
+        best.mse,
+        best.pretty,
+        best.params,
+    );
+}
+
+#[test]
+fn eml_tree_matches_reported_mse_adam() {
+    // y = exp(x) - 5. Fitting requires eml(x, c) = exp(x) - ln(c) with
+    // c = exp(5) =~ 148.4, far from the topology's default "One" leaf value
+    // of 1.0 — so an unparameterized `eml_tree` (the pre-fix bug) would be
+    // off by a constant 5 everywhere, not accidentally close to correct.
+    let inputs: Vec<Vec<f64>> = (0..20).map(|i| vec![i as f64 * 0.25]).collect();
+    let targets: Vec<f64> = inputs.iter().map(|x| x[0].exp() - 5.0).collect();
+
+    let config = SymRegConfig {
+        max_depth: 2,
+        learning_rate: 1e-2,
+        tolerance: 1e-9,
+        max_iter: 2000,
+        num_restarts: 3,
+        ..SymRegConfig::default()
+    };
+    assert_eml_tree_matches_reported_mse(&inputs, &targets, config);
+}
+
+#[test]
+fn eml_tree_matches_reported_mse_levenberg_marquardt() {
+    let inputs: Vec<Vec<f64>> = (0..20).map(|i| vec![i as f64 * 0.25]).collect();
+    let targets: Vec<f64> = inputs.iter().map(|x| x[0].exp() - 5.0).collect();
+
+    let config = SymRegConfig {
+        max_depth: 2,
+        tolerance: 1e-9,
+        max_iter: 200,
+        num_restarts: 3,
+        optimizer: OptimizerKind::LevenbergMarquardt,
+        ..SymRegConfig::default()
+    };
+    assert_eml_tree_matches_reported_mse(&inputs, &targets, config);
+}


### PR DESCRIPTION
## Summary

Fixes #2.

`DiscoveredFormula.eml_tree` was always `topology.clone()` — the raw, unparameterized tree (every `One`/`Const` leaf still at its un-fitted placeholder value) — while `mse`/`pretty` were computed from a separately parameterized expression (`final_op`, built from `best_params`). The two were silently inconsistent: evaluating `eml_tree` directly via `eval_batch`/`eval_real` (the exact pattern used by every README example — `pendulum.rs`, `harmonic_oscillator.rs`) produces predictions unrelated to the formula's reported quality, off by however far the optimizer moved the parameters from their `1.0` init value.

## Fix

Adds `bake_params_into_tree` (`src/symreg/constants.rs`) — an `EmlTree`-level counterpart to the existing `bake_params_into_lowered` — which reuses the existing `substitute_params` leaf-substitution helper. `substitute_params` already walks the topology in the same left-to-right leaf order that `ParameterizedEmlTree`'s tape builder (`src/grad.rs::build_tape_recursive`) uses to assign parameter indices during Adam/Jacobian optimization, so the resulting tree is index-consistent with `best_params` by construction (verified by the new regression test below).

Applied at all three production call sites that previously did `eml_tree: topology.clone()`:
- `src/symreg/discover.rs` — Adam path (`optimize_topology_adam`)
- `src/symreg/optimize_lm.rs` — Levenberg-Marquardt path
- `src/symreg/discover_shared.rs` — shared-topology multi-output path (`discover_multi`), baking each output's own `per_output_params` independently

(`src/grad.rs`/test-only construction sites in `mod.rs`/`uncertainty.rs` were not touched — those use empty `params`, so there's nothing to bake.)

## Test plan

Added `tests/symreg_eml_tree_consistency_test.rs`: discovers a formula for `y = exp(x) - 5` (chosen so the fitted parameter, `c = exp(5) ≈ 148.4`, is far from the topology's default `1.0` leaf value — `y = exp(x)` alone doesn't catch the bug, since the correct param happens to coincide with the default), then evaluates the returned `eml_tree` directly and asserts the manually recomputed MSE matches `formula.mse`. Covers both `OptimizerKind::Adam` and `OptimizerKind::LevenbergMarquardt`.

- Confirmed this test **fails on `master`** with the exact symptom from #2 (e.g. `eml_tree's own evaluation (mse=2.500000e1 ...) does not match the formula's reported mse (5.916457e-31)`)
- Confirmed it **passes** with this fix
- `cargo test --release --lib --tests --features parallel`: 353+ tests, 0 failures (no regressions)
- `cargo clippy --release --features parallel -- -D warnings`: clean

## Note: a second, separate issue

While verifying this fix against a real workload (numerically solving the hydrogen-atom radial Schrödinger equation and feeding the resulting energy levels to `discover()`), I found that `optimize_topology_adam`'s residual loop silently drops any training point where `ptree.forward_with_jacobian_into` returns `Err`/non-finite, without tracking or surfacing how many points were excluded — so `mse` can be computed over a shrunken subset of the data and look deceptively good even when the formula fails badly on excluded points. `compute_mse_direct`/`compute_mse_parameterized` in `topology.rs` have the same silent-drop pattern. This is a separate, more invasive issue (touches the acceptance/scoring semantics, not just a field-construction bug) and is out of scope for this PR — happy to file it separately if useful, just didn't want to bundle two different kinds of fixes into one PR.
